### PR TITLE
use env var instead of set-output command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ echo "Building firmware"
 result=$(pio run | sed -nE "s/^Building (.+).bin/\1/p")
 binary_path="$result.bin"
 echo "Output binary: $binary_path"
-echo "::set-output name=binary::$binary_path"
+echo "binary=$binary_path" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Reason:** `set-output` is being [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)